### PR TITLE
Mtp

### DIFF
--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -710,7 +710,7 @@ class MTPProposer(Proposer):
 
                 # For speculative decoding
                 self.model_inputs["output_cum_offsets"].copy_(output_cum_offsets, False)
-                self.model_inputs["output_padding_offset"].copy(output_padding_offset, False)
+                self.model_inputs["output_padding_offset"].copy_(output_padding_offset, False)
 
                 # Initialize forward meta data
                 self._initialize_forward_meta()

--- a/fastdeploy/spec_decode/mtp.py
+++ b/fastdeploy/spec_decode/mtp.py
@@ -709,8 +709,8 @@ class MTPProposer(Proposer):
                 self.model_inputs["cu_seqlens_k"].copy_(cu_seqlens_k, False)
 
                 # For speculative decoding
-                self.model_inputs["output_cum_offsets"] = output_cum_offsets
-                self.model_inputs["output_padding_offset"] = output_padding_offset
+                self.model_inputs["output_cum_offsets"].copy_(output_cum_offsets, False)
+                self.model_inputs["output_padding_offset"].copy(output_padding_offset, False)
 
                 # Initialize forward meta data
                 self._initialize_forward_meta()


### PR DESCRIPTION
存在一些每轮step时地址会变动的中间变量（并不是模型前向传播需要的输入），目前怀疑特殊情况下（比如资源紧张场景）其某一轮可能会分配到某块被Cudagraph捕获的空间，当cudagraph replay之后，会改这些变量的值，导致后续错误。
目前可以通过把模型输入无关的变量的地址都固定住来解决，但是不是长久之策，后续需要定位到为什么一块空间会被分配两次。